### PR TITLE
Support API key from variable source directly

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ export interface Config extends BaseConfig {
 // Checks whether an object is a FileConfig.
 function isFileConfig(o: any): o is FileConfig {
   if (typeof o !== "object") return false;
-  if (!(o.apiKeySource === "env" || o.apiKeySource === "file")) return false;
+  if (!(o.apiKeySource === "env" || o.apiKeySource === "file" || typeof o.apiKeySource === "string")) return false;
   if (typeof o.deploymentID !== "string") return false;
   if ("allowUpdateAddress" in o) {
     const value = o.allowUpdateAddress;
@@ -70,8 +70,10 @@ export default function getConfig(): Config {
       throw new Error(`Environment variable ${APIKeyEnvKey} not found`);
     }
     apiKey = env;
-  } else {
+  } else if (mbConfig.apiKeySource === "file") {
     apiKey = readFileSync(path.join(process.cwd(), APIKeyFileName), "utf-8");
+  } else {
+    apiKey = mbConfig.apiKeySource;
   }
   return { allowUpdateAddress: false, ...mbConfig, apiKey };
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -11,6 +11,7 @@ interface Options {
   shareNonce?: boolean;
   walletHdpath?: string;
   insecureOk?: boolean;
+  apiKey?: string;
 }
 
 /**
@@ -31,10 +32,12 @@ export default class Provider extends provider {
     deploymentID: string,
     options: Options = { insecureOk: false },
   ) {
+    const apiKey = options.apiKey || process.env[Web3APIEnvKey];
+
     super(
       // @ts-ignore
       mnemonic,
-      `${getHost(deploymentID, options.insecureOk)}/web3/${process.env[Web3APIEnvKey]}`,
+      `${getHost(deploymentID, options.insecureOk)}/web3/${apiKey}`,
       options.addressIndex,
       options.numAddresses,
       options.shareNonce,


### PR DESCRIPTION
In case of switching an environment variable name, passing a direct value of API key is better than that.